### PR TITLE
ci: add CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,98 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-bun:
+    runs-on: ubuntu-latest
+    name: Build MCP Server (Bun)
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build MCP Server
+        run: bun run build
+
+      - name: Compile to standalone executable
+        run: bun run compile
+
+  build-node:
+    runs-on: ubuntu-latest
+    name: Build MCP Server (Node.js)
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build MCP Server
+        run: npm run build
+
+  build-docker:
+    runs-on: ubuntu-latest
+    name: Build MCP Server Docker Image
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@e61617a16c407a86262fb923c35a616ddbe070b3 # v4.6.0
+        with:
+          daemon-config: |
+            {
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
+        with:
+          registry: https://dhi.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build Docker image
+        uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6.10.0
+        with:
+          files: docker-bake.hcl
+          push: false
+          no-cache: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          SOURCE_DATE_EPOCH: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,54 @@
+name: Lint
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint Codebase
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run ESLint
+        run: bun run lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    name: Lint Codebase
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run type check
+        run: bun run typecheck

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,17 @@
+target "default" {
+  dockerfile = "Dockerfile"
+  tags       = ["ghcr.io/sjinks/wpscan-mcp-server:latest"]
+  platforms  = ["linux/amd64", "linux/arm64"]
+  pull       = true
+  output = [
+    "type=docker"
+  ]
+
+  cache-from = [
+    "type=gha"
+  ]
+
+  cache-to = [
+    "type=gha,mode=max"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "start:node": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "generate-types": "openapi-typescript https://wpscan.com/docs/api/v3/v3.yml/ -o src/wpscan/wpscan.d.ts",
-    "prepare": "bun run generate-types",
     "compile": "bun build --compile --bytecode --outfile=wpscan-mcp src/index.ts"
   },
   "dependencies": {


### PR DESCRIPTION
This pull request introduces GitHub Actions workflows for building, linting, and type checking the project, as well as configuration for Docker image builds. These changes automate CI/CD processes, ensuring code quality and consistent build outputs across different environments.

**Continuous Integration & Build Automation**

* Added `.github/workflows/build.yml` to automate building the MCP Server using Bun, Node.js, and Docker, including steps for dependency installation, building, compiling, and Docker image creation and registry login.
* Added `.github/workflows/lint.yml` to automate linting and type checking using Bun, ensuring code quality on every push and pull request.

**Docker Build Configuration**

* Added `docker-bake.hcl` to define Docker build targets, multi-platform support, image tagging, and cache settings for efficient and reproducible Docker builds.

**Minor Package Script Update**

* Removed the `prepare` script from `package.json`, which previously generated types before other install steps.