### PR TITLE
ci: add publish workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,5 +94,3 @@ jobs:
           files: docker-bake.hcl
           push: false
           no-cache: ${{ github.event_name == 'workflow_dispatch' }}
-        env:
-          SOURCE_DATE_EPOCH: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
-    name: Lint Codebase
+    name: Run Type Check
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,116 @@
+name: Publish Package
+
+on:
+  release:
+    types:
+      - released
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      id-token: write
+    steps:
+      - name: Set commit status to PENDING
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+          context: Publish to npm
+          sha: ${{ github.sha }}
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Node.js environment
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          registry-url: https://registry.npmjs.org/
+
+      - name: Update npm
+        run: sudo npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm i
+
+      - name: Build MCP Server
+        run: npm run build
+
+      - name: Publish package
+        run: npm publish
+
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          context: Publish to npm
+          sha: ${{ github.sha }}
+        if: always()
+
+  publish-docker:
+    name: Publish Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
+      packages: write
+    steps:
+      - name: Set commit status to PENDING
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+          context: Publish to ghcr.io
+          sha: ${{ github.sha }}
+
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Log in to Docker Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Set tag name
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          echo "TAG_NAME=${TAG_NAME#v}" >> "${GITHUB_ENV}"
+
+      - name: Build Docker image
+        uses: docker/bake-action@5be5f02ff8819ecd3092ea6b2e6261c31774f2b4 # v6.10.0
+        with:
+          files: docker-bake.hcl
+          push: true
+          no-cache: ${{ github.event_name == 'workflow_dispatch' }}
+          provenance: true
+          sbom: true
+          set: |
+            *.tags+=ghcr.io/sjinks/wpscan-mcp-server:${{ env.TAG_NAME }}
+            *.output=type=image,push=true,rewrite-timestamp=true
+        env:
+          SOURCE_DATE_EPOCH: 0
+
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}
+          context: Publish to ghcr.io
+          sha: ${{ github.sha }}
+        if: always()

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -1,0 +1,26 @@
+name: Prepare Release
+
+on:
+  push:
+    tags:
+      - "**"
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Prepare the release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Create a release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.REPOSITORY_ACCESS_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@wwa/wpscan-mcp",
   "version": "0.1.0",
-  "private": true,
   "description": "MCP server for the WPScan (wpscan.com) API",
   "type": "module",
   "main": "dist/index.js",
@@ -34,5 +33,8 @@
   "publishConfig": {
     "access": "public",
     "provenance": true
-  }
+  },
+  "files": [
+    "dist/**/*.js"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
   },
   "keywords": ["mcp", "wpscan", "wordpress", "vulnerability", "scanner"],
   "author": "Volodymyr Kolesnykov <volodymyr@wildwolf.name> (https://wildwolf.name/)",
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  }
 }


### PR DESCRIPTION
This pull request introduces automated workflows for releasing and publishing the package, as well as updates to the `package.json` to support public publishing. The changes streamline the release process by adding CI/CD pipelines for preparing releases, publishing to npm, and publishing Docker images. Additionally, the package is now configured for public distribution.

**CI/CD and Release Automation:**

* Added `.github/workflows/push-tag.yml` to automatically create a GitHub release with generated release notes when a tag is pushed.
* Added `.github/workflows/publish.yml` to automate publishing the package to npm and Docker images to GitHub Container Registry on release or manual trigger. This includes setting commit statuses, building, and publishing steps.

**Package Configuration for Public Publishing:**

* Removed `"private": true` from `package.json` to allow public publishing.
* Added `publishConfig` with `access: public` and `provenance: true` to `package.json`, and specified published files as `dist/**/*.js`.

**Build Workflow Adjustment:**

* Removed the `SOURCE_DATE_EPOCH` environment variable from the build workflow in `.github/workflows/build.yml` to avoid unnecessary environment settings.